### PR TITLE
feat: 필요없는 asmr 레코드 삭제하는 Scheduler 추가

### DIFF
--- a/src/main/java/com/example/hearhere/HearhereApplication.java
+++ b/src/main/java/com/example/hearhere/HearhereApplication.java
@@ -2,7 +2,9 @@ package com.example.hearhere;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class HearhereApplication {
 

--- a/src/main/java/com/example/hearhere/repository/AsmrRepository.java
+++ b/src/main/java/com/example/hearhere/repository/AsmrRepository.java
@@ -2,14 +2,22 @@ package com.example.hearhere.repository;
 
 import com.example.hearhere.entity.Asmr;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 
 @Repository
 public interface AsmrRepository extends JpaRepository<Asmr, Long> {
     @Query(nativeQuery = true, value = "SELECT * FROM asmr WHERE asmr.user_id=:userId")
     ArrayList<Asmr> findAllByUserId(@Param("userId") String userId);
+
+    @Modifying
+    @Transactional
+    @Query(value = "DELETE FROM asmr WHERE user_id IS NULL AND generated_time <= :cutoffTime", nativeQuery = true)
+    void deleteOldRecordsWithoutUserId(@Param("cutoffTime") String cutoffTime);
 }

--- a/src/main/java/com/example/hearhere/service/InvalidAsmrDeleteScheduler.java
+++ b/src/main/java/com/example/hearhere/service/InvalidAsmrDeleteScheduler.java
@@ -1,0 +1,23 @@
+package com.example.hearhere.service;
+
+import com.example.hearhere.repository.AsmrRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+@Service
+public class InvalidAsmrDeleteScheduler {
+    @Autowired
+    private AsmrRepository asmrRepository;
+
+    @Scheduled(fixedDelay = 1000*60*60)
+    public void deleteInvalidAsmr() {
+        LocalDateTime cutoffTime = LocalDateTime.now().minusDays(1);
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+        asmrRepository.deleteOldRecordsWithoutUserId(formatter.format(cutoffTime));
+    }
+
+}


### PR DESCRIPTION
# Task Summary (*필수)
필요없는 asmr 레코드 삭제하는 Scheduler 추가

# Changes (*필수)
1. generate api에 요청 들어올 시 처음부터 asmr 테이블에 불필요할 수 있는 내용 저장, asmrId 리턴
2. save api에 요청 들어올 시 사실상 POST가 아닌 PATCH 요청으로 처리, 해당 레코드 업데이트
3. **주기적으로 불필요한 asmr 레코드(최종 저장된 게 아닌 최초 생성되기만 한 asmr 레코드) 삭제 -> 1시간마다 확인, 1일 이상 저장되었으나 userId가 없는 레코드 삭제**


# PR 유형 (*필수)
- [ ] Bug Fix (fix)
- [X] New Features (feat)
- [ ] Test (test)
- [ ] Document modification (docs)
- [ ] Refactoring (refactor)
- [ ] Styling (style)
- [ ] ETC, No production code change (chore)
- [ ] Build task and Dependency management (build)

# Screenshot

# Reference
