### PR TITLE
feat: 태그로 소리요소 검색 기능 추가

### DIFF
--- a/src/main/java/com/example/hearhere/dto/GenerateAsmrResponseDto.java
+++ b/src/main/java/com/example/hearhere/dto/GenerateAsmrResponseDto.java
@@ -1,11 +1,14 @@
 package com.example.hearhere.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @NoArgsConstructor
 @AllArgsConstructor
@@ -15,5 +18,12 @@ public class GenerateAsmrResponseDto {
     private Long asmrId;
     private String title;
     private String musicUrl;
-    private ArrayList<String> soundUrls;
+    private ArrayList<SoundDetailDto> soundDetails;
+
+    @JsonIgnore
+    public List<String> getSoundUrls() {
+        return soundDetails.stream()
+                .map(SoundDetailDto::getUrl)
+                .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/com/example/hearhere/dto/SoundDetailDto.java
+++ b/src/main/java/com/example/hearhere/dto/SoundDetailDto.java
@@ -1,0 +1,16 @@
+package com.example.hearhere.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class SoundDetailDto {
+    private Long soundId;
+    private String url;
+    private String length;
+}

--- a/src/main/java/com/example/hearhere/entity/Sound.java
+++ b/src/main/java/com/example/hearhere/entity/Sound.java
@@ -1,0 +1,34 @@
+package com.example.hearhere.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+public class Sound {
+    @Id
+    @Column(name = "sound_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long soundId;
+
+    @Column(name = "name", length = 100)
+    private String name;
+
+    @Column(name = "category", length = 50)
+    private String category;
+
+    @Column(name = "tag", length = 100)
+    private String tag;
+
+    @Column(name = "intensity", length = 50)
+    private String intensity;
+
+    @Column(name = "length", length = 10)
+    private String length;
+}

--- a/src/main/java/com/example/hearhere/repository/SoundRepository.java
+++ b/src/main/java/com/example/hearhere/repository/SoundRepository.java
@@ -1,0 +1,17 @@
+package com.example.hearhere.repository;
+
+import com.example.hearhere.entity.Sound;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface SoundRepository extends JpaRepository<Sound, Long> {
+    @Query(value = "SELECT * FROM sound s WHERE s.tag LIKE CONCAT('%', :tag, '%')",
+            nativeQuery = true)
+    List<Sound> findByTag(
+            @Param("tag") String tag);
+}

--- a/src/main/java/com/example/hearhere/service/AudioSearchService.java
+++ b/src/main/java/com/example/hearhere/service/AudioSearchService.java
@@ -1,13 +1,66 @@
 package com.example.hearhere.service;
 
+import com.example.hearhere.dto.SoundDetailDto;
+import com.example.hearhere.entity.Sound;
+import com.example.hearhere.repository.SoundRepository;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
+import java.util.stream.Collectors;
 
+@Slf4j
 @Service
 public class AudioSearchService {
-    public ArrayList<String> searchSoundByPrompt(List<String> audioPromptList) {
-        return null;
+    @Autowired
+    private SoundRepository soundRepository;
+    @Value("${s3.basic.url}")
+    private String s3Url;
+
+    public ArrayList<SoundDetailDto> searchSoundByPrompt(List<Map<String, String>> audioPromptList) {
+        log.info("audioPromptList\n" + audioPromptList.toString());
+
+        ArrayList<SoundDetailDto> soundDetailList = new ArrayList<>(); // Set을 사용하여 중복 제거
+
+        for (Map<String, String> prompt : audioPromptList) {
+            String category = prompt.get("category");
+            Object tagObject = prompt.get("tag");
+            List<String> tags;
+
+            if (tagObject instanceof List) {
+                tags = (List<String>) tagObject;
+            } else {
+                tags = new ArrayList<>();
+            }
+            log.info(tags.toString());
+            String intensity = prompt.get("intensity");
+
+            List<Sound> sounds = new ArrayList<>();
+
+            for (String tag : tags) {
+                sounds.addAll(soundRepository.findByTag(tag));
+            }
+
+            for (Sound sound : sounds) {
+                SoundDetailDto soundDetailDto = new SoundDetailDto(
+                        sound.getSoundId(),
+                        s3Url + sound.getName() + ".wav",
+                        sound.getLength()
+                );
+                boolean exists = soundDetailList.stream()
+                        .anyMatch(existingDetail -> existingDetail.getUrl().equals(soundDetailDto.getUrl()));
+
+                if (!exists) {
+                    soundDetailList.add(soundDetailDto);
+                }
+            }
+        }
+
+        return soundDetailList;
     }
 }

--- a/src/main/java/com/example/hearhere/service/ChatGptService.java
+++ b/src/main/java/com/example/hearhere/service/ChatGptService.java
@@ -20,12 +20,23 @@ public class ChatGptService {
     private final ObjectMapper objectMapper = new ObjectMapper(); // Jackson ObjectMapper
 
     public Map<String, Object> generateTitle(String prompt) {
-        String systemMessage = "You are a creative assistant responsible for generating short, catchy music titles. Based on the user’s prompt, create a unique and fitting music title that is no more than 20 characters long. The title should be provided in a JSON format as: {\"title\": \"String\"}. You MUST ONLY return final JSON message.";
+        String systemMessage = "You are a creative assistant responsible for generating short, catchy music titles. Based on the user’s prompt, create a unique and fitting music title that is no more than 20 characters long. The title should be provided in a JSON format as: {\"title\": \"String\"}. You MUST ONLY return final JSON message IN ENGLISH.";
         return generateChat(prompt, systemMessage);
     }
 
     public Map<String, Object> generatePrompt(String prompt) {
-        String systemMessage = "Imagine and extend the given user message in a descriptive manner. Then, extract auditory elements from the extended user message and return them in a JSON format with two keys: \"music\" and \"sound\". \"music\" should include keywords related to music elements, such as genres, instruments, background music (BGM), etc. \"sound\" should include keywords related to general sounds, such as environmental noises, human sounds, and other non-musical auditory experiences. Each key should contain 6 values. You MUST ONLY return final JSON message.";
+        // 프롬프트 생성
+        String systemMessage = "You MUST ONLY return the final JSON message IN ENGLISH. Imagine and expand upon the given user message in a descriptive manner to identify music and sound elements.\n" +
+                "\n" +
+                "Each sound element should have:\n" +
+                "\"category\": Choose between 'city,' 'nature,' or 'object.'\n" +
+                "\"tag\": Select up to 3 tags from the provided list that best describe the sound. Each tag should be in ONE WORD.\n" +
+                "\"intensity\": Describe as 'strong,' 'weak,' or 'none.'\n" +
+                "\n" +
+                "For 'music,' only include keywords related to genres, instruments, or background themes. Avoid specifying category, tag, or intensity for 'music' elements.\n" +
+                "Each key, 'music' and 'sound,' should contain 6 values. Format each element in the JSON to reflect this structured approach.\n" +
+                "\n" +
+                "You MUST ONLY return the final JSON message IN ENGLISH.";
         return generateChat(prompt, systemMessage);
     }
 


### PR DESCRIPTION
# Task Summary (*필수)
태그로 소리요소 검색 기능 추가

# Changes (*필수)
* ChatGPT API를 사용해 키워드당 3개의 one-word tag 생성
* 태그가 포함된 소리 요소가 있으면 리턴, 중복 제거

# PR 유형 (*필수)
- [ ] Bug Fix (fix)
- [X] New Features (feat)
- [ ] Test (test)
- [ ] Document modification (docs)
- [ ] Refactoring (refactor)
- [ ] Styling (style)
- [ ] ETC, No production code change (chore)
- [ ] Build task and Dependency management (build)

# Screenshot

# Reference
