### PR TITLE
feat: 로그인 리다이렉트 URI env, action 따라 달라지도록 수정

### DIFF
--- a/src/main/java/com/example/hearhere/security/SecurityConfig.java
+++ b/src/main/java/com/example/hearhere/security/SecurityConfig.java
@@ -1,20 +1,19 @@
 package com.example.hearhere.security;
 
 import com.example.hearhere.security.jwt.JwtUtil;
+import com.example.hearhere.security.oauth2.OAuth2EnvActionFilter;
 import com.example.hearhere.security.oauth2.OAuthLoginFailureHandler;
 import com.example.hearhere.security.oauth2.OAuthLoginSuccessHandler;
 import com.example.hearhere.service.TokenBlacklistService;
-import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestRedirectFilter;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
-import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -64,6 +63,7 @@ public class SecurityConfig {
                 )
                 .logout(logout -> logout.disable())
                 .addFilterBefore(new JwtAuthenticationFilter(jwtUtil, tokenBlacklistService), UsernamePasswordAuthenticationFilter.class)  // JWT 필터 추가
+                .addFilterBefore(new OAuth2EnvActionFilter(), OAuth2AuthorizationRequestRedirectFilter.class)
                 .oauth2Login(oauth ->
                         oauth
                                 .successHandler(oAuthLoginSuccessHandler) // 로그인 성공 시 핸들러

--- a/src/main/java/com/example/hearhere/security/oauth2/OAuth2EnvActionFilter.java
+++ b/src/main/java/com/example/hearhere/security/oauth2/OAuth2EnvActionFilter.java
@@ -1,0 +1,42 @@
+package com.example.hearhere.security.oauth2;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+public class OAuth2EnvActionFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String requestURI = request.getRequestURI();
+        if (requestURI.startsWith("/oauth2/authorization/")) {
+            String env = request.getParameter("env");
+            if (env != null) {
+                log.info("env 파라미터 감지: {}", env);
+
+                // env 값을 세션에 저장
+                request.getSession().setAttribute("env", env);
+                log.info("env 값 세션에 저장 완료: {}", env);
+            }
+
+            String action = request.getParameter("action");
+            if (action != null) {
+                log.info("action 파라미터 감지: {}", action);
+
+                // action 값을 세션에 저장
+                request.getSession().setAttribute("action", action);
+                log.info("action 값 세션에 저장 완료: {}", action);
+            }
+        }
+        // 다음 필터로 요청 전달
+        filterChain.doFilter(request, response);
+    }
+}


### PR DESCRIPTION
# Task Summary (*필수)
로그인 리다이렉트 URI를 환경(개발/배포), action(기본로그인/저장로그인)에 따라 달라지도록 Security 필터를 추가하고, Login 성공 핸들러도 수정했습니다

# Changes (*필수)
* OAuth2EnvActionFilter: URI 쿼리 파라미터로 env, action 값을 받아서 세션에 저장
* SecurityConfig: SecurityFilterChain에 OAuth2EnvActionFilter 추가
* OAuthLoginSuccessHandler: 로그인 성공 시 핸들러로, 세션에 저장된 env, action 값을 키로 URI 해쉬맵에서 사용할 URI 검색 및 결정

# PR 유형 (*필수)
- [ ] Bug Fix (fix)
- [X] New Features (feat)
- [ ] Test (test)
- [ ] Document modification (docs)
- [ ] Refactoring (refactor)
- [ ] Styling (style)
- [ ] ETC, No production code change (chore)
- [ ] Build task and Dependency management (build)

# Screenshot

# Reference
